### PR TITLE
fix(search): categories search sync

### DIFF
--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -795,8 +795,9 @@ export interface Search {
   categories?:
     | {
         relationTo?: string | null;
-        id?: string | null;
+        categoryID?: string | null;
         title?: string | null;
+        id?: string | null;
       }[]
     | null;
   updatedAt: string;
@@ -1465,8 +1466,9 @@ export interface SearchSelect<T extends boolean = true> {
     | T
     | {
         relationTo?: T;
-        id?: T;
+        categoryID?: T;
         title?: T;
+        id?: T;
       };
   updatedAt?: T;
   createdAt?: T;

--- a/src/search/beforeSync.ts
+++ b/src/search/beforeSync.ts
@@ -1,6 +1,7 @@
 import type { BeforeSync, DocToSync } from "@payloadcms/plugin-search/types";
 
 export const beforeSyncWithSearch: BeforeSync = async ({
+  req,
   originalDoc,
   searchDoc,
 }) => {
@@ -23,24 +24,40 @@ export const beforeSyncWithSearch: BeforeSync = async ({
   };
 
   if (categories && Array.isArray(categories) && categories.length > 0) {
-    // get full categories and keep a flattened copy of their most important properties
-    try {
-      const mappedCategories = categories.map((category) => {
-        const { id, title } = category;
+    const populatedCategories: { id: string | number; title: string }[] = [];
+    for (const category of categories) {
+      if (!category) {
+        continue;
+      }
 
-        return {
-          relationTo: "categories",
-          id,
-          title,
-        };
+      if (typeof category === "object") {
+        populatedCategories.push(category);
+        continue;
+      }
+
+      const doc = await req.payload.findByID({
+        collection: "categories",
+        id: category,
+        disableErrors: true,
+        depth: 0,
+        select: { title: true },
+        req,
       });
 
-      modifiedDoc.categories = mappedCategories;
-    } catch (_err) {
-      console.error(
-        `Failed. Category not found when syncing collection '${collection}' with id: '${id}' to search.`,
-      );
+      if (doc !== null) {
+        populatedCategories.push(doc);
+      } else {
+        console.error(
+          `Failed. Category not found when syncing collection '${collection}' with id: '${id}' to search.`,
+        );
+      }
     }
+
+    modifiedDoc.categories = populatedCategories.map((each) => ({
+      relationTo: "categories",
+      categoryID: String(each.id),
+      title: each.title,
+    }));
   }
 
   return modifiedDoc;

--- a/src/search/fieldOverrides.ts
+++ b/src/search/fieldOverrides.ts
@@ -49,7 +49,7 @@ export const searchFields: Field[] = [
         type: "text",
       },
       {
-        name: "id",
+        name: "categoryID",
         type: "text",
       },
       {


### PR DESCRIPTION
* https://github.com/payloadcms/payload/pull/12359
* Previously, search sync with categories didn't work and additionally caused problems with Postgres. Additionally, ensures that when doing synchronization, all the categories are populated, since we don't always have populated data inside hooks.